### PR TITLE
feature: 修改bft quorum阈值

### DIFF
--- a/consensus/dpos/bft.go
+++ b/consensus/dpos/bft.go
@@ -48,7 +48,8 @@ type BftManager struct {
 }
 
 func newBftManager(dp *Dpos) *BftManager {
-	q := (dp.config.WitnessesNum-1)/3*2 + 1 // 2f+1
+	n := dp.config.WitnessesNum
+	q := n - (n-1)/3 // N-f
 	return &BftManager{
 		dp:          dp,
 		quorum:      q,

--- a/consensus/dpos/msg_pool_test.go
+++ b/consensus/dpos/msg_pool_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMsgPool_GetOrNewRoundMsgPool(t *testing.T) {
-	// f = 1
+	// n = 4, f = 1
 	quo := 3
 	mp := newMsgPool(quo, "test")
 	h := big.NewInt(1)
@@ -45,7 +45,7 @@ func TestMsgPool_GetOrNewRoundMsgPool(t *testing.T) {
 }
 
 func TestMsgPool_AddMsgAndMajoritySuccess(t *testing.T) {
-	// f = 1
+	// n = 4, f = 1
 	quo := 3
 	mp := newMsgPool(quo, "test")
 	h := big.NewInt(1)
@@ -151,7 +151,7 @@ func TestMsgPool_AddMsgAndMajoritySuccess(t *testing.T) {
 }
 
 func TestMsgPool_MajorityFail(t *testing.T) {
-	// f = 1
+	// n = 4, f = 1
 	quo := 3
 	mp := newMsgPool(quo, "test")
 	h := big.NewInt(1)
@@ -206,6 +206,7 @@ func TestMsgPool_MajorityFail(t *testing.T) {
 }
 
 func TestMsgPool_cleanOldMessage(t *testing.T) {
+	// n = 4, f = 1
 	quo := 3
 	mp := newMsgPool(quo, "test")
 	h1 := big.NewInt(100)
@@ -260,6 +261,7 @@ func TestMsgPool_cleanOldMessage(t *testing.T) {
 }
 
 func TestCleanOldMsg(t *testing.T) {
+	// n = 4, f = 1
 	quo := 3
 	mp := newMsgPool(quo, "test")
 


### PR DESCRIPTION
当见证人节点数为N时，`f = (N-1)/3`，向下取整，则bft达到共识的要求节点数为: `N-f`。