### PR TITLE
Fix p2p mem leak

### DIFF
--- a/vntp2p/dial.go
+++ b/vntp2p/dial.go
@@ -203,8 +203,11 @@ func (t *dialTask) checkTarget() bool {
 	return true
 }
 
-func (t *dialTask) dial(ctx context.Context, server *Server, target peer.ID, pid string) error {
-	return server.SetupStream(ctx, target, pid)
+func (t *dialTask) dial(ctx context.Context, server *Server, target peer.ID, pid string) (err error) {
+	if err = server.SetupStream(ctx, target, pid); err != nil {
+		log.Trace("Dial failed", "error", err)
+	}
+	return
 }
 
 func (t *lookupTask) Do(ctx context.Context, server *Server) {

--- a/vntp2p/message.go
+++ b/vntp2p/message.go
@@ -193,7 +193,7 @@ func (rw *VNTMessenger) WriteMsg(msg Msg) (err error) {
 		log.Error("WriteMsg()", "write msg error", err)
 		if !rw.peerPointer.closed {
 			log.Info("WriteMsg()", "underlay will close this connection which remotePID", rw.peerPointer.RemoteID())
-			rw.peerPointer.err <- err
+			rw.peerPointer.sendError(err)
 		}
 		log.Trace("WriteMsg() exit", "peer", rw.peerPointer.RemoteID())
 		return err
@@ -209,7 +209,7 @@ func (rw *VNTMessenger) ReadMsg() (Msg, error) {
 		return msg, nil
 	case err := <-rw.err:
 		return Msg{}, err
-	case <- rw.peerPointer.server.quit:
+	case <-rw.peerPointer.server.quit:
 		log.Info("P2P server is being closed, no longer read message...")
 		return Msg{}, errServerStopped
 	}

--- a/vntp2p/message.go
+++ b/vntp2p/message.go
@@ -107,7 +107,7 @@ type msgHandler func() error
 // Send is used to send message payload with specific messge type
 func Send(w MsgWriter, protocolID string, msgType MessageType, data interface{}) error {
 	// 还是要使用rlp进行序列化，因为类型多变，rlp已经有完整的支持
-	log.Info("yhx-test", "send message type", msgType)
+	log.Info("Send message", "type", msgType)
 	size, r, err := rlp.EncodeToReader(data)
 	if err != nil {
 		log.Error("Send()", "rlp encode error", err)

--- a/vntp2p/protocol.go
+++ b/vntp2p/protocol.go
@@ -97,9 +97,9 @@ func (server *Server) HandleStream(s inet.Stream) {
 			// 非阻塞向上层协议传递消息，如果2s还未被读取，认为上层协议有故障
 			select {
 			case msger.in <- msg:
-				break
+				log.Trace("HandleStream send message to messager success")
 			case <-time.NewTimer(time.Second * 2).C:
-				break
+				log.Trace("HandleStream send message to messager timeout")
 			}
 		} else {
 			log.Warn("HandleStream", "receive unknown message", msg)

--- a/vntp2p/protocol.go
+++ b/vntp2p/protocol.go
@@ -44,15 +44,15 @@ type Protocol struct {
 func (server *Server) HandleStream(s inet.Stream) {
 	// 发生错误时才会退出
 	defer func() {
-		log.Info("HandleStream reset stream before exit")
+		log.Debug("HandleStream reset stream before exit")
 		s.Reset()
 	}()
 
 	// peer信息只获取1次即可
-	log.Info("p2p-test, stream data comming")
+	log.Debug("p2p-test, stream data comming")
 	peer := server.GetPeerByRemoteID(s)
 	if peer == nil {
-		log.Info("HandleStream", "localPeerID", s.Conn().LocalPeer(), "remotePeerID", s.Conn().RemotePeer(), "this remote peer is nil, don't handle it")
+		log.Debug("HandleStream", "localPeerID", s.Conn().LocalPeer(), "remotePeerID", s.Conn().RemotePeer(), "this remote peer is nil, don't handle it")
 		return
 	}
 
@@ -62,7 +62,7 @@ func (server *Server) HandleStream(s inet.Stream) {
 		msgHeaderByte := make([]byte, MessageHeaderLength)
 		_, err := io.ReadFull(s, msgHeaderByte)
 		if err != nil {
-			log.Error("handleStream", "read header error", err)
+			log.Error("handleStream", "read header error", err, "peer", peer.RemoteID().ToString())
 			notifyError(peer.messenger, err)
 			return
 		}
@@ -71,14 +71,14 @@ func (server *Server) HandleStream(s inet.Stream) {
 		msgBodyByte := make([]byte, bodySize)
 		_, err = io.ReadFull(s, msgBodyByte)
 		if err != nil {
-			log.Error("handleStream", "read msgBody error", err)
+			log.Error("handleStream", "read msgBody error", err, "peer", peer.RemoteID().ToString())
 			notifyError(peer.messenger, err)
 			return
 		}
 		msgBody := &MsgBody{Payload: &rlp.EncReader{}}
 		err = json.Unmarshal(msgBodyByte, msgBody)
 		if err != nil {
-			log.Error("handleSteam", "unmarshal msgBody error", err)
+			log.Error("handleSteam", "unmarshal msgBody error", err, "peer", peer.RemoteID().ToString())
 			notifyError(peer.messenger, err)
 			return
 		}
@@ -101,8 +101,8 @@ func (server *Server) HandleStream(s inet.Stream) {
 }
 
 func notifyError(messengers map[string]*VNTMessenger, err error) {
-	log.Error("notifyError enter")
-	defer log.Error("notifyError exit")
+	log.Trace("notifyError enter")
+	defer log.Trace("notifyError exit")
 	for _, m := range messengers {
 		m.err <- err
 	}

--- a/vntp2p/server.go
+++ b/vntp2p/server.go
@@ -279,12 +279,9 @@ func (server *Server) run(ctx context.Context, tasker taskworker) {
 
 		case pd := <-server.delpeer:
 			// A peer disconnected.
-
 			pid := pd.RemoteID()
 			log.Info("Removing p2p peer", "peer", pid.ToString())
-			if p, ok := peers[pid]; ok {
-				log.Info("Reset peer stream", "peer", pid.ToString())
-				p.Reset()
+			if _, ok := peers[pid]; ok {
 				delete(peers, pid)
 			}
 		}

--- a/vntp2p/server.go
+++ b/vntp2p/server.go
@@ -36,7 +36,6 @@ import (
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	ma "github.com/multiformats/go-multiaddr"
 	// kb "github.com/libp2p/go-libp2p-kbucket"
-	// "time"
 )
 
 const (
@@ -281,8 +280,13 @@ func (server *Server) run(ctx context.Context, tasker taskworker) {
 		case pd := <-server.delpeer:
 			// A peer disconnected.
 
-			log.Info("Removing p2p peer", "peers", pd.RemoteID())
-			delete(peers, pd.RemoteID())
+			pid := pd.RemoteID()
+			log.Info("Removing p2p peer", "peer", pid.ToString())
+			if p, ok := peers[pid]; ok {
+				log.Info("Reset peer stream", "peer", pid.ToString())
+				p.Reset()
+				delete(peers, pid)
+			}
 		}
 	}
 }
@@ -411,6 +415,7 @@ func (server *Server) maxDialedConns() int {
 	return server.MaxPeers / r
 }
 
+// SetupStream 主动发起连接
 func (server *Server) SetupStream(ctx context.Context, target peer.ID, pid string) error {
 	// log.Info("p2p-test", "SetupStream target", target, "pid", pid)
 	s, err := server.host.NewStream(ctx, target, protocol.ID(pid))

--- a/vntp2p/server.go
+++ b/vntp2p/server.go
@@ -280,7 +280,7 @@ func (server *Server) run(ctx context.Context, tasker taskworker) {
 		case pd := <-server.delpeer:
 			// A peer disconnected.
 			pid := pd.RemoteID()
-			log.Info("Removing p2p peer", "peer", pid.ToString())
+			log.Info("Removing p2p peer", "peer", pid.ToString(), "error", pd.err)
 			if _, ok := peers[pid]; ok {
 				delete(peers, pid)
 			}

--- a/whisper/whisperv6/peer.go
+++ b/whisper/whisperv6/peer.go
@@ -22,11 +22,11 @@ import (
 	"sync"
 	"time"
 
+	libp2p "github.com/libp2p/go-libp2p-peer"
 	"github.com/vntchain/go-vnt/common"
 	"github.com/vntchain/go-vnt/log"
 	"github.com/vntchain/go-vnt/rlp"
 	"github.com/vntchain/go-vnt/vntp2p"
-	libp2p "github.com/libp2p/go-libp2p-peer"
 	set "gopkg.in/fatih/set.v0"
 )
 
@@ -66,13 +66,13 @@ func newPeer(host *Whisper, remote *vntp2p.Peer, rw vntp2p.MsgReadWriter) *Peer 
 // into the network.
 func (peer *Peer) start() {
 	go peer.update()
-	log.Trace("start", "peer", peer.ID())
+	log.Trace("Whisper6 peer start", "peer", peer.ID())
 }
 
 // stop terminates the peer updater, stopping message forwarding to it.
 func (peer *Peer) stop() {
 	close(peer.quit)
-	log.Trace("stop", "peer", peer.ID())
+	log.Trace("Whisper6 peer stop", "peer", peer.ID())
 }
 
 // handshake sends the protocol initiation status message to the remote peer and

--- a/whisper/whisperv6/whisper.go
+++ b/whisper/whisperv6/whisper.go
@@ -651,7 +651,7 @@ func (whisper *Whisper) runMessageLoop(p *Peer, rw vntp2p.MsgReadWriter) error {
 		// fetch the next packet
 		packet, err := rw.ReadMsg()
 		if err != nil {
-			log.Warn("message loop", "peer", p.peer.RemoteID(), "err", err)
+			log.Warn("Whisper6 message loop", "peer", p.peer.RemoteID(), "err", err)
 			return err
 		}
 		if packet.GetBodySize() > whisper.MaxMessageSize() {


### PR DESCRIPTION
This PR is to fix memory leak in vntp2p. goroutine leaks is the leading cause of the memory leak.

3 ways to fix goroutine leaks:
- close stream when there is an error
- using buffered channel and unblock way to send error for a peer
- using timeout to send message in HandleStream

