### PR TITLE
Refactor peer management

### DIFF
--- a/cmd/faucet/faucet.go
+++ b/cmd/faucet/faucet.go
@@ -262,7 +262,7 @@ func newFaucet(rctx context.Context, genesis *core.Genesis, port int, vnodes []*
 
 	for _, boot := range vnodes {
 		// old, _ := vntp2p.ParseNode(boot.String())
-		stack.Server().AddPeer(rctx, boot)
+		stack.Server().AddStaticPeer(rctx, boot)
 	}
 	// Attach to the client and retrieve and interesting metadatas
 	api, err := stack.Attach()

--- a/cmd/swarm/main.go
+++ b/cmd/swarm/main.go
@@ -548,6 +548,6 @@ func injectBootnodes(srv *vntp2p.Server, nodes []string) {
 			log.Error("Invalid swarm bootnode", "err", err)
 			continue
 		}
-		srv.AddPeer(context.Background(), n)
+		srv.AddStaticPeer(context.Background(), n)
 	}
 }

--- a/les/serverpool.go
+++ b/les/serverpool.go
@@ -505,7 +505,7 @@ func (pool *serverPool) dial(entry *poolEntry, knownSelected bool) {
 	log.Debug("Dialing new peer", "lesaddr", entry.id.String()+"@"+addr.strKey(), "set", len(entry.addr), "known", knownSelected)
 	entry.dialed = addr
 	go func() {
-		pool.server.AddPeer(ctx, vntp2p.NewNode(entry.id, addr.ip, addr.port, addr.port))
+		pool.server.AddStaticPeer(ctx, vntp2p.NewNode(entry.id, addr.ip, addr.port, addr.port))
 		select {
 		case <-pool.quit:
 		case <-time.After(dialTimeout):

--- a/node/api.go
+++ b/node/api.go
@@ -41,7 +41,7 @@ func NewPrivateAdminAPI(node *Node) *PrivateAdminAPI {
 	return &PrivateAdminAPI{node: node}
 }
 
-// AddPeer requests connecting to a remote node, and also maintaining the new
+// AddStaticPeer requests connecting to a remote node, and also maintaining the new
 // connection at all times, even reconnecting if it is lost.
 func (api *PrivateAdminAPI) AddPeer(url string) (bool, error) {
 	// Make sure the server is running, fail otherwise
@@ -55,7 +55,7 @@ func (api *PrivateAdminAPI) AddPeer(url string) (bool, error) {
 		return false, fmt.Errorf("invalid enode: %v", err)
 	}
 	ctx := context.Background()
-	server.AddPeer(ctx, node)
+	server.AddStaticPeer(ctx, node)
 	return true, nil
 }
 

--- a/swarm/swarm.go
+++ b/swarm/swarm.go
@@ -280,7 +280,7 @@ func (self *Swarm) Start(srv *vntp2p.Server) error {
 		if err != nil {
 			return fmt.Errorf("invalid node URL: %v", err)
 		}
-		srv.AddPeer(ctx, node)
+		srv.AddStaticPeer(ctx, node)
 		return nil
 	}
 	// set chequebook

--- a/vnt/handler.go
+++ b/vnt/handler.go
@@ -230,7 +230,7 @@ func (pm *ProtocolManager) resetBftPeer(urls []string) {
 		pm.peers.bftPeers[node.Id] = struct{}{}
 		if _, exists := pm.peers.peers[node.Id]; !exists {
 			log.Debug("Reset bft peer, connecting to", "peer", url)
-			go pm.node.Server().AddPeer(context.Background(), node)
+			go pm.node.Server().AddStaticPeer(context.Background(), node)
 		}
 	}
 }

--- a/vnt/peer.go
+++ b/vnt/peer.go
@@ -57,7 +57,7 @@ const (
 	// above some healthy uncle limit, so use that.
 	maxQueuedAnns = 4
 
-	handshakeTimeout = 5 * time.Second
+	handshakeTimeout = 10 * time.Second
 )
 
 // PeerInfo represents a short summary of the VNT sub-protocol metadata known

--- a/vnt/peer.go
+++ b/vnt/peer.go
@@ -57,7 +57,7 @@ const (
 	// above some healthy uncle limit, so use that.
 	maxQueuedAnns = 4
 
-	handshakeTimeout = 10 * time.Second
+	handshakeTimeout = 5 * time.Second
 )
 
 // PeerInfo represents a short summary of the VNT sub-protocol metadata known

--- a/vntp2p/peer.go
+++ b/vntp2p/peer.go
@@ -92,8 +92,8 @@ type Peer struct {
 
 func newPeer(s *Stream, server *Server) *Peer {
 	m := make(map[string]*VNTMsger)
-	for i := range s.Protocols {
-		proto := s.Protocols[i]
+	// Create msgers for each sub protocol
+	for _, proto := range s.Protocols {
 		vntMessenger := &VNTMsger{
 			protocol: proto,
 			in:       make(chan Msg),

--- a/vntp2p/peer_error.go
+++ b/vntp2p/peer_error.go
@@ -69,6 +69,7 @@ const (
 	DiscUnexpectedIdentity
 	DiscSelf
 	DiscReadTimeout
+	DiscHostQuit
 	DiscSubprotocolError = 0x10
 )
 
@@ -85,6 +86,7 @@ var discReasonToString = [...]string{
 	DiscUnexpectedIdentity:  "unexpected identity",
 	DiscSelf:                "connected to self",
 	DiscReadTimeout:         "read timeout",
+	DiscHostQuit:            "host quit",
 	DiscSubprotocolError:    "subprotocol error",
 }
 

--- a/vntp2p/protocol.go
+++ b/vntp2p/protocol.go
@@ -44,9 +44,9 @@ type Protocol struct {
 func (server *Server) HandleStream(s inet.Stream) {
 	// peer信息只获取1次即可
 	log.Debug("Stream data coming...")
-	peer := server.GetPeerByRemoteID(s)
+	peer := server.addPeer(s)
 	if peer == nil {
-		log.Debug("HandleStream", "remotePeerID", s.Conn().RemotePeer(), "this remote peer is nil, don't handle it")
+		log.Debug("HandleStream", "peer", s.Conn().RemotePeer(), "error", "this remote peer is nil, don't handle it")
 		_ = s.Reset()
 		return
 	}

--- a/vntp2p/server.go
+++ b/vntp2p/server.go
@@ -233,7 +233,6 @@ func (server *Server) run(ctx context.Context, tasker taskworker) {
 		case t := <-taskdone:
 			tasker.taskDone(t)
 			delTask(t)
-
 		case t := <-server.addStatic:
 			log.Debug("Adding static", "peer id", t.Id)
 			tasker.addStatic(t)
@@ -243,9 +242,13 @@ func (server *Server) run(ctx context.Context, tasker taskworker) {
 			if p, ok := peers[t.Id]; ok {
 				p.Disconnect(DiscRequested)
 			}
-
 		case op := <-server.peerOp:
 			op(peers)
+		case <-server.quit:
+			for _, p := range peers {
+				p.Disconnect(DiscHostQuit)
+			}
+			return
 		}
 	}
 }


### PR DESCRIPTION
1. add peer从2个入口统一为1个入口
2. 统一peer的操作，只使用opPeer通道
2. 修复节点关闭不主动断开连接的问题，该问题会造成peer节点认为该peer连接仍在
3. 重构一些变量名称