### PR TITLE
Drop protocal in-compatible peer

### DIFF
--- a/vnt/peer.go
+++ b/vnt/peer.go
@@ -378,6 +378,8 @@ func (p *peer) readStatus(network uint64, status *statusData, genesis common.Has
 		return errResp(ErrDecode, "msg %v: %v", msg, err)
 	}
 	if status.GenesisBlock != genesis {
+		// this peer is mismatch with local node, drop it
+		p.Peer.Drop()
 		return errResp(ErrGenesisBlockMismatch, "%x (!= %x)", status.GenesisBlock[:8], genesis[:8])
 	}
 	if status.NetworkId != network {

--- a/vntp2p/peer.go
+++ b/vntp2p/peer.go
@@ -118,6 +118,11 @@ func newPeer(s *Stream, server *Server) *Peer {
 	return p
 }
 
+// Drop this peer forever because of protocol mismatch
+func (p *Peer) Drop() {
+	p.rw.Conn().Close()
+}
+
 // LocalID return local PeerID for upper application
 func (p *Peer) LocalID() libp2p.ID {
 	return p.rw.Conn().LocalPeer()


### PR DESCRIPTION
Drop incompatible peers from ipfs bucket so that it will not connect to bad peer again.